### PR TITLE
Fixed: Duplicate Line Bug

### DIFF
--- a/generate-self-signed-cert.sh
+++ b/generate-self-signed-cert.sh
@@ -76,7 +76,6 @@ while test $# -gt 0; do
             ca_file="${2}"
             shift 2
             ;;
-            ;;
         --cert-ext)
             cert_ext="${2}"
             shift 2


### PR DESCRIPTION
Removed a link in the generate-self-signed-cert.sh script line that caused a shell error.